### PR TITLE
Use `buildSubgraph` method to parse/build fed2 subgraphs

### DIFF
--- a/src/federation/two.js
+++ b/src/federation/two.js
@@ -1,9 +1,8 @@
 import { compose } from '@apollo/composition';
 import {
-  buildSchema,
-  FederationBlueprint,
+  buildSubgraph,
+  errorCauses,
   operationFromDocument,
-  Subgraph,
   Subgraphs,
 } from '@apollo/federation-internals';
 import { QueryPlanner } from '@apollo/query-planner';
@@ -18,19 +17,19 @@ export async function composeWithResolvedConfig(config) {
 
   for (const [name, { url, schema: sdl }] of Object.entries(config.subgraphs)) {
     try {
-      const schema = buildSchema(sdl, {
-        blueprint: new FederationBlueprint(),
-        validate: false,
-      });
-
-      const subgraph = new Subgraph(
+      const subgraph = buildSubgraph(
         name,
         url ?? 'http://localhost:4001',
-        schema,
+        sdl
       );
-
       subgraphs.add(subgraph);
     } catch (e) {
+      const graphQLCauses = errorCauses(e);
+      if (graphQLCauses) {
+        return {
+          errors: graphQLCauses
+        };
+      }
       throw new Error(`failed to build schema for ${name} subgraph`);
     }
   }


### PR DESCRIPTION
This commits slightly update the code building fed2 subgraph schema to mimick what the fed2 uses. In practice, the only visible changes compared to the previous code is that the subgraph name will now be used when pointing to location errors. Meaning that instead of:
```
GraphQL Request:10:20
9  |   rating: Int
10 |   product: Product @provides(fields: "price")
   |                    ^
11 | }
```
it will now show:
```
reviews:10:20
9  |   rating: Int
10 |   product: Product @provides(fields: "price")
   |                    ^
11 | }
```

But this also make slighly more unlikely that this readiness tool behaviour diverges from the fed2 actual one.