### PR TITLE
Generate mmd files for each query plan

### DIFF
--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -19,6 +19,7 @@ import { composeWithResolvedConfig as composeWithResolvedConfig1 } from '../fede
 import { composeWithResolvedConfig as composeWithResolvedConfig2 } from '../federation/two.js';
 import { getClient } from '../studio/index.js';
 import { queryPlanAudit } from '../federation/query-plan-audit.js';
+import { queryPlanToMermaid } from '../federation/queryPlanToMermaid.js';
 
 const FROM_OPTIONS = {
   'Last Hour': '-3600',
@@ -377,8 +378,24 @@ export default class AuditCommand extends Command {
         const name = `${result.queryName ?? 'Unnamed'}-${result.queryId.slice(
           0,
           6,
-        )}.md`;
-        const path = join(this.out, name);
+        )}`;
+        const path = join(this.out, `${name}.md`);
+        const diagramPathFed1 = join(this.out, `${name}-fed1.mmd`);
+        const diagramPathFed2 = join(this.out, `${name}-fed2.mmd`);
+
+        // Write Mermaid diagrams
+        // eslint-disable-next-line no-await-in-loop
+        await writeFile(
+            diagramPathFed1,
+            queryPlanToMermaid(result.one),
+            'utf-8',
+        );
+        // eslint-disable-next-line no-await-in-loop
+        await writeFile(
+            diagramPathFed2,
+            queryPlanToMermaid(result.two),
+            'utf-8',
+        );
 
         if (result.type === 'SUCCESS' && !result.queryPlansMatch) {
           // eslint-disable-next-line no-await-in-loop

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -384,18 +384,22 @@ export default class AuditCommand extends Command {
         const diagramPathFed2 = join(this.out, `${name}-fed2.mmd`);
 
         // Write Mermaid diagrams
-        // eslint-disable-next-line no-await-in-loop
-        await writeFile(
-            diagramPathFed1,
-            queryPlanToMermaid(result.one),
-            'utf-8',
-        );
-        // eslint-disable-next-line no-await-in-loop
-        await writeFile(
-            diagramPathFed2,
-            queryPlanToMermaid(result.two),
-            'utf-8',
-        );
+        if (result.one) {
+          // eslint-disable-next-line no-await-in-loop
+          await writeFile(
+              diagramPathFed1,
+              queryPlanToMermaid(result.one),
+              'utf-8',
+          );
+        }
+        if (result.two) {
+          // eslint-disable-next-line no-await-in-loop
+          await writeFile(
+              diagramPathFed2,
+              queryPlanToMermaid(result.two),
+              'utf-8',
+          );
+        }
 
         if (result.type === 'SUCCESS' && !result.queryPlansMatch) {
           // eslint-disable-next-line no-await-in-loop

--- a/src/federation/queryPlanToMermaid.js
+++ b/src/federation/queryPlanToMermaid.js
@@ -1,0 +1,96 @@
+function hash() {
+  return (Date.now() + Math.random().toString()).replaceAll('.', '');
+}
+
+/**
+ * This code comes from the Studio-UI repo. We should talk with that team if we want a
+ * sharable package
+ *
+ * https://github.com/mdg-private/studio-ui/blob/f4341fd691794e68901b5122403b038749d15a82/src/app/graph/explorerPage/resultsPane/queryPlan/queryPlanToMermaid.ts#L137
+ */
+function process(currentNode) {
+  switch (currentNode.kind) {
+    case 'Sequence': {
+      const processedChildren = currentNode.nodes.map(process);
+      return {
+        // TODO: Remove non null assertion, added when turning on noUncheckedIndexedAccess
+        startHash: processedChildren[0]?.startHash,
+        // TODO: Remove non null assertion, added when turning on noUncheckedIndexedAccess
+        endHash: processedChildren.slice(-1)[0]?.endHash,
+        nodeText: processedChildren
+          .map((processedChild, i) => {
+            if (i === 0) return processedChild.nodeText;
+            const link = `${processedChildren[i - 1]?.endHash} --> ${
+              processedChild.startHash
+            }`;
+            return `
+              ${link}
+              ${processedChild.nodeText}
+            `;
+          })
+          .join(''),
+      };
+    }
+    case 'Parallel': {
+      const nodeHash = hash();
+      return {
+        startHash: nodeHash,
+        endHash: nodeHash,
+        nodeText: `
+          ${nodeHash}("Parallel")
+
+          ${currentNode.nodes
+    .map((node) => {
+      const processedChild = process(node);
+      return `
+                ${nodeHash} --> ${processedChild.startHash}
+                ${processedChild.nodeText}
+              `;
+    })
+    .join('')}
+        `,
+      };
+    }
+    case 'Fetch': {
+      // TODO (jason) get tooltips to work here, seems to not be creating the
+      // node at all. Should create node with class .mermaidTooltip
+      // const tooltip = currentNode.operation
+      //   ? `${currentNodeHash}_operation["${print(
+      //       parse(currentNode.operation),
+      //     ).replaceAll('\n', '<br/>')}"] -...- ${currentNodeHash}`
+      //   : 'click ${nodeHash} unDefinedCallback "TooltipContents"';
+      const nodeHash = hash();
+      return {
+        startHash: nodeHash,
+        endHash: nodeHash,
+        nodeText: `${nodeHash}("Fetch (${currentNode.serviceName})")`,
+      };
+    }
+    case 'Flatten': {
+      const nodeHash = hash();
+      const processedChild = process(currentNode.node);
+
+      return {
+        startHash: processedChild.startHash,
+        endHash: nodeHash,
+        nodeText: `
+          ${nodeHash}("Flatten (${currentNode.path
+  .join(',')
+  .replaceAll('@', '[]')})")
+          
+          ${processedChild.endHash} --> ${nodeHash}
+          ${processedChild.nodeText}
+        `,
+      };
+    }
+    default:
+      return currentNode;
+  }
+}
+
+export function queryPlanToMermaid(queryPlan) {
+  return `
+    graph TD
+      ${process(queryPlan.node).nodeText}
+  `.trim();
+}

--- a/src/federation/queryPlanToMermaid.js
+++ b/src/federation/queryPlanToMermaid.js
@@ -7,6 +7,8 @@ function hash() {
  * sharable package
  *
  * https://github.com/mdg-private/studio-ui/blob/f4341fd691794e68901b5122403b038749d15a82/src/app/graph/explorerPage/resultsPane/queryPlan/queryPlanToMermaid.ts#L137
+ * @param {import("@apollo/query-planner-1").PlanNode|import("@apollo/query-planner").PlanNode} currentNode
+ * @return {{nodeText: string, startHash: string, endHash: string}}
  */
 function process(currentNode) {
   switch (currentNode.kind) {
@@ -88,9 +90,18 @@ function process(currentNode) {
   }
 }
 
+/**
+ * @param {import("@apollo/query-planner").QueryPlan|import("@apollo/query-planner-1").QueryPlan} queryPlan
+ * @return {string}
+ */
 export function queryPlanToMermaid(queryPlan) {
+  const queryPlanNode = queryPlan.node;
+  if (!queryPlanNode) {
+    throw new Error('Invalid query plan');
+  }
+
   return `
     graph TD
-      ${process(queryPlan.node).nodeText}
+      ${process(queryPlanNode).nodeText}
   `.trim();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6648,7 +6648,7 @@ unique-slug@^2.0.0:
 
 universalify@^0.1.2:
   version "0.1.2"
-  resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unixify@^1.0.0:


### PR DESCRIPTION
This generates a `.mmd` file for both fed1 and fed2. This file is just text but you can install a plugin for your IDE to view them and GitHub supports viewing the visual diagrams.


Example from the peloton graph
![Screen Shot 2022-05-04 at 3 33 06 PM](https://user-images.githubusercontent.com/2446877/166836183-6148a211-4688-40d2-b578-97448f3c8118.png)
