### PR TITLE
Disable diagrams by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test": "node --experimental-vm-modules $(yarn bin)/jest src",
     "test:debug": "node --inspect-brk --experimental-vm-modules $(yarn bin)/jest src",
     "dev": "node bin/index.js",
-    "dev:customer": "node bin/index.js audit --account <account-name>"
+    "dev:customer": "node bin/index.js audit --account <account-name>",
+    "check:lint": "yarn eslint",
+    "check:tcs": "yarn tsc"
   },
   "dependencies": {
     "@apollo/composition": "^2.0.0",

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -286,6 +286,12 @@ export default class AuditCommand extends Command {
     description: 'Optional. Path to a directory to store audit results.',
   });
 
+  includeDiagrams = Option.Boolean('--include-diagrams', {
+    required: false,
+    description: 'Optional. Include a visual .mmd file of the query plans. ' +
+        'There may be some issues with specific query plans.',
+  });
+
   async execute() {
     const spinner = ora();
     const client = await getClient(this.key, {
@@ -384,7 +390,7 @@ export default class AuditCommand extends Command {
         const diagramPathFed2 = join(this.out, `${name}-fed2.mmd`);
 
         // Write Mermaid diagrams
-        if (result.one) {
+        if (result.one && this.includeDiagrams) {
           // eslint-disable-next-line no-await-in-loop
           await writeFile(
               diagramPathFed1,
@@ -392,7 +398,7 @@ export default class AuditCommand extends Command {
               'utf-8',
           );
         }
-        if (result.two) {
+        if (result.two && this.includeDiagrams) {
           // eslint-disable-next-line no-await-in-loop
           await writeFile(
               diagramPathFed2,

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -391,20 +391,19 @@ export default class AuditCommand extends Command {
 
         // Write Mermaid diagrams
         if (result.one && this.includeDiagrams) {
-          // eslint-disable-next-line no-await-in-loop
-          await writeFile(
-              diagramPathFed1,
-              queryPlanToMermaid(result.one),
-              'utf-8',
-          );
+          const mermaidFed1 = queryPlanToMermaid(this.context, diagramPathFed1, result.one);
+          if (mermaidFed1) {
+            // eslint-disable-next-line no-await-in-loop
+            await writeFile(diagramPathFed1, mermaidFed1, 'utf-8');
+          }
         }
+
         if (result.two && this.includeDiagrams) {
-          // eslint-disable-next-line no-await-in-loop
-          await writeFile(
-              diagramPathFed2,
-              queryPlanToMermaid(result.two),
-              'utf-8',
-          );
+          const mermaidFed2 = queryPlanToMermaid(this.context, diagramPathFed2, result.two);
+          if (mermaidFed2) {
+            // eslint-disable-next-line no-await-in-loop
+            await writeFile(diagramPathFed2, mermaidFed2, 'utf-8');
+          }
         }
 
         if (result.type === 'SUCCESS' && !result.queryPlansMatch) {

--- a/src/federation/queryPlanToMermaid.js
+++ b/src/federation/queryPlanToMermaid.js
@@ -91,17 +91,25 @@ function process(currentNode) {
 }
 
 /**
+ * @param {import("clipanion").BaseContext} context
+ * @param {string} queryName
  * @param {import("@apollo/query-planner").QueryPlan|import("@apollo/query-planner-1").QueryPlan} queryPlan
  * @return {string}
  */
-export function queryPlanToMermaid(queryPlan) {
+export function queryPlanToMermaid(context, queryName, queryPlan) {
   const queryPlanNode = queryPlan.node;
   if (!queryPlanNode) {
-    throw new Error('Invalid query plan');
+    context.stdout.write(`Invalid query plan for ${queryName}. Will not generate a visual diagram.\n`);
+    return '';
   }
 
-  return `
+  try {
+    return `
     graph TD
       ${process(queryPlanNode).nodeText}
   `.trim();
+  } catch (e) {
+    context.stdout.write(`Error processing query plan for ${queryName}. Will not generate a visual diagram.\n`);
+    return '';
+  }
 }


### PR DESCRIPTION
Disable generating diagrams by default and better handle errors when generating them by just logging a message instead of throwing an error