### PR TITLE
Upgrade `@apollo` libraries and fix usage of fed-internals

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "check:tcs": "yarn tsc"
   },
   "dependencies": {
-    "@apollo/composition": "^2.2.1",
+    "@apollo/composition": "^2.5.7",
     "@apollo/federation-1": "npm:@apollo/federation@0.37.1",
-    "@apollo/federation-internals": "^2.2.1",
-    "@apollo/gateway": "^2.2.1",
-    "@apollo/query-planner": "^2.2.1",
+    "@apollo/federation-internals": "^2.5.7",
+    "@apollo/gateway": "^2.5.7",
+    "@apollo/query-planner": "^2.5.7",
     "@apollo/query-planner-1": "npm:@apollo/query-planner@0.11.1",
-    "@apollo/subgraph": "^2.2.1",
+    "@apollo/subgraph": "^2.5.7",
     "@urql/core": "^2.6.0",
     "cli-progress": "^3.11.2",
     "clipanion": "^3.2.0-rc.11",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev": "node bin/index.js",
     "dev:customer": "node bin/index.js audit --account <account-name>",
     "check:lint": "yarn eslint",
-    "check:tcs": "yarn tsc"
+    "check:tsc": "yarn tsc"
   },
   "dependencies": {
     "@apollo/composition": "^2.5.7",

--- a/src/federation/normalize-2.js
+++ b/src/federation/normalize-2.js
@@ -4,6 +4,7 @@ import { parse, print, visit } from 'graphql';
  * @typedef {import('@apollo/query-planner').QueryPlanSelectionNode} QueryPlanSelectionNode
  * @typedef {import('@apollo/query-planner').QueryPlan} QueryPlan
  * @typedef {import('@apollo/query-planner').PlanNode} PlanNode
+ * @typedef {import('@apollo/query-planner').SubscriptionNode} SubscriptionNode
  * @typedef {import('../typings').QueryPlanVisitor2} QueryPlanVisitor
  */
 
@@ -14,7 +15,7 @@ import { parse, print, visit } from 'graphql';
 function visitQueryPlan(plan, visitor) {
   const newPlan = { ...plan };
   /**
-   * @param {PlanNode} node
+   * @param {PlanNode | SubscriptionNode} node
    */
   function recurse(node) {
     const newNode = { ...node };

--- a/src/federation/two.js
+++ b/src/federation/two.js
@@ -1,10 +1,10 @@
 import { compose } from '@apollo/composition';
 import {
   buildSubgraph,
-  buildSupergraphSchema,
   errorCauses,
   operationFromDocument,
   Subgraphs,
+  Supergraph,
 } from '@apollo/federation-internals';
 import { QueryPlanner } from '@apollo/query-planner';
 import { GraphQLError, parse } from 'graphql';
@@ -58,7 +58,8 @@ export function queryPlan(schema, operationDoc, operationName) {
   const operation = operationFromDocument(schema, documentNode, {
     operationName,
   });
-  const queryPlanner = new QueryPlanner(schema);
+  const supergraph = new Supergraph(schema, null, false);
+  const queryPlanner = new QueryPlanner(supergraph);
   return queryPlanner.buildQueryPlan(operation);
 }
 
@@ -73,10 +74,12 @@ export function queryPlanWithFed1Schema(
   operationName,
 ) {
   const documentNode = parse(operationDoc);
-  const [schema] = buildSupergraphSchema(supergraphSdl);
-  const operation = operationFromDocument(schema, documentNode, {
+  const supergraph = Supergraph.build(supergraphSdl, {
+    validateSupergraph: true,
+  });
+  const operation = operationFromDocument(supergraph.schema, documentNode, {
     operationName,
   });
-  const queryPlanner = new QueryPlanner(schema);
+  const queryPlanner = new QueryPlanner(supergraph);
   return queryPlanner.buildQueryPlan(operation);
 }

--- a/src/federation/two.test.js
+++ b/src/federation/two.test.js
@@ -72,11 +72,13 @@ Object {
     "nodes": Array [
       Object {
         "id": undefined,
+        "inputRewrites": undefined,
         "kind": "Fetch",
         "operation": "query Search__products__0($search:[String!]){products(search:$search){__typename id name}}",
         "operationDocumentNode": undefined,
         "operationKind": "query",
         "operationName": "Search__products__0",
+        "outputRewrites": undefined,
         "requires": undefined,
         "serviceName": "products",
         "variableUsages": Array [
@@ -87,11 +89,13 @@ Object {
         "kind": "Flatten",
         "node": Object {
           "id": undefined,
+          "inputRewrites": undefined,
           "kind": "Fetch",
           "operation": "query Search__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{rating}}}}",
           "operationDocumentNode": undefined,
           "operationKind": "query",
           "operationName": "Search__reviews__1",
+          "outputRewrites": undefined,
           "requires": Array [
             Object {
               "kind": "InlineFragment",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,13 +15,13 @@
   resolved "https://registry.yarnpkg.com/@apollo/cache-control-types/-/cache-control-types-1.0.2.tgz#f42ed3563acc7f1f50617d65d208483977adc68e"
   integrity sha512-Por80co1eUm4ATsvjCOoS/tIR8PHxqVjsA6z76I6Vw0rFn4cgyVElQcmQDIZiYsy41k8e5xkrMRECkM2WR8pNw==
 
-"@apollo/composition@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@apollo/composition/-/composition-2.2.1.tgz#9078088abcdab166f0fa4271b2af2d3d342a0b2a"
-  integrity sha512-xmd4NiCU+rW6elTZuIflR+GzZf626fJX7NVraTHXgDL8pZ7eluPal/T6vsQEg+Cb9tlAUjDhCB4RqVYPgV69RQ==
+"@apollo/composition@2.5.7", "@apollo/composition@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@apollo/composition/-/composition-2.5.7.tgz#4b7cb60b5c9d2d42829b9fe15b699ce0fdc89549"
+  integrity sha512-Yx0F+GqKU0Yy6GJF7Rw7wgC5wPLG3eoReN7FUibswpZavf8HNTNniZu0BcB/rtOrAmznwCXkLw97KfAHQoj6YA==
   dependencies:
-    "@apollo/federation-internals" "^2.2.1"
-    "@apollo/query-graphs" "^2.2.1"
+    "@apollo/federation-internals" "2.5.7"
+    "@apollo/query-graphs" "2.5.7"
 
 "@apollo/federation-1@npm:@apollo/federation@0.37.1":
   version "0.37.1"
@@ -32,34 +32,36 @@
     apollo-server-types "^3.0.2"
     lodash.xorby "^4.7.0"
 
-"@apollo/federation-internals@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@apollo/federation-internals/-/federation-internals-2.2.1.tgz#348e842c328e5dbf8138f4542ab968367d2d44ec"
-  integrity sha512-T+nxIhppu/5jNFIhfzYERIhgDvp2QqbSqnQpViDNEmK/iPKsXLFtOedZZgsAUpMIQoUedNNNuceTE9+lDUn+bA==
+"@apollo/federation-internals@2.5.7", "@apollo/federation-internals@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@apollo/federation-internals/-/federation-internals-2.5.7.tgz#82dabc55765b76475141b6b4d69de5b325b59c3b"
+  integrity sha512-+c7m2c4FG4lMURZhtjFP59mm4/0zM49w6C/9uxryXriZKG3l3n5Ay12V/w9LNm7laoQkZjIBECBU39yT40mdBw==
   dependencies:
+    "@types/uuid" "^9.0.0"
     chalk "^4.1.0"
     js-levenshtein "^1.1.6"
+    uuid "^9.0.0"
 
-"@apollo/gateway@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@apollo/gateway/-/gateway-2.2.1.tgz#dda88e9fb35790e21d5d51a6411bbae3e86e253c"
-  integrity sha512-dCUs6KJq5FU8ZYQj2KLeR++cPmKZ1al3AC00fufHLuFKR7XjsXsPZsHPY+Tt39QZI56tNrUdiiR2rjQ17c4Zew==
+"@apollo/gateway@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@apollo/gateway/-/gateway-2.5.7.tgz#b67aca59bc82208e97b2f3c7d57cf95ca786cb8c"
+  integrity sha512-hLI15fg8O9FCCjo0f7H4CcMy6f2ux/U5MW1BU63xLtwJWCcxJhv2aaiEjdIkg4+RwbGB1JCPtQQ7EYZfNm+uXg==
   dependencies:
-    "@apollo/composition" "^2.2.1"
-    "@apollo/federation-internals" "^2.2.1"
-    "@apollo/query-planner" "^2.2.1"
-    "@apollo/server-gateway-interface" "^1.0.2"
-    "@apollo/usage-reporting-protobuf" "^4.0.0"
-    "@apollo/utils.createhash" "^1.1.0"
-    "@apollo/utils.fetcher" "^1.1.0"
-    "@apollo/utils.isnodelike" "^1.1.0"
-    "@apollo/utils.logger" "^1.0.0"
+    "@apollo/composition" "2.5.7"
+    "@apollo/federation-internals" "2.5.7"
+    "@apollo/query-planner" "2.5.7"
+    "@apollo/server-gateway-interface" "^1.1.0"
+    "@apollo/usage-reporting-protobuf" "^4.1.0"
+    "@apollo/utils.createhash" "^2.0.0"
+    "@apollo/utils.fetcher" "^2.0.0"
+    "@apollo/utils.isnodelike" "^2.0.0"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
+    "@apollo/utils.logger" "^2.0.0"
     "@josephg/resolvable" "^1.0.1"
     "@opentelemetry/api" "^1.0.1"
     "@types/node-fetch" "^2.6.2"
     async-retry "^1.3.3"
     loglevel "^1.6.1"
-    lru-cache "^7.13.1"
     make-fetch-happen "^11.0.0"
     node-abort-controller "^3.0.1"
     node-fetch "^2.6.7"
@@ -83,10 +85,10 @@
     "@types/node" "^10.1.0"
     long "^4.0.0"
 
-"@apollo/protobufjs@1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.6.tgz#d601e65211e06ae1432bf5993a1a0105f2862f27"
-  integrity sha512-Wqo1oSHNUj/jxmsVp4iR3I480p6qdqHikn38lKrFhfzcDJ7lwd7Ck7cHRl4JE81tWNArl77xhnG/OkZhxKBYOw==
+"@apollo/protobufjs@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.7.tgz#3a8675512817e4a046a897e5f4f16415f16a7d8a"
+  integrity sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -99,18 +101,16 @@
     "@protobufjs/pool" "^1.1.0"
     "@protobufjs/utf8" "^1.1.0"
     "@types/long" "^4.0.0"
-    "@types/node" "^10.1.0"
     long "^4.0.0"
 
-"@apollo/query-graphs@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@apollo/query-graphs/-/query-graphs-2.2.1.tgz#d8cec6eb026deb53bcbe62fb68f9fc309b33bd17"
-  integrity sha512-lDK1HfsJlM4P2AcdhNYxXnq5zWohyLiWVyhC0SEnhR/BRfoP2UOC31MHK0waRLAQP5SBMBVolRn6AhtSFNmEyA==
+"@apollo/query-graphs@2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@apollo/query-graphs/-/query-graphs-2.5.7.tgz#c92b49ac3f7213762a71f2b027e0e039f0908006"
+  integrity sha512-6kWJw4dYrk70jLEy/5fcfDaKB0vaFYe+NoLwDEZu7K3U4Y191xxNwUbjxkmQZSBwQ95beGrtOu7XWmJCnzKPlA==
   dependencies:
-    "@apollo/federation-internals" "^2.2.1"
-    "@types/uuid" "^8.3.4"
+    "@apollo/federation-internals" "2.5.7"
     deep-equal "^2.0.5"
-    ts-graphviz "^0.16.0"
+    ts-graphviz "^1.5.4"
     uuid "^9.0.0"
 
 "@apollo/query-planner-1@npm:@apollo/query-planner@0.11.1":
@@ -122,26 +122,27 @@
     deep-equal "^2.0.5"
     pretty-format "^28.0.0"
 
-"@apollo/query-planner@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@apollo/query-planner/-/query-planner-2.2.1.tgz#77534c7429c47e210d7a39174b0682c305b4554b"
-  integrity sha512-U1OmN2Zvq/xs9OL4iK6Wauw9mIYLsTug4YEfnK/MdaWhkKtRyYsDxgUlPqzUYEZMS9LESqhODJ/IobbsbTJjJQ==
+"@apollo/query-planner@2.5.7", "@apollo/query-planner@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@apollo/query-planner/-/query-planner-2.5.7.tgz#e1b540ee55c856cb3be80ab2ef506dc4aa9ffc80"
+  integrity sha512-WQ6UZNkd52M1OT+K1/OdfK/+8ktgj+KVr97QRm91eoydHldyG6oBuxC/1zdTKPY8wzL1ku6xNwRiAMUNe5cNZg==
   dependencies:
-    "@apollo/federation-internals" "^2.2.1"
-    "@apollo/query-graphs" "^2.2.1"
+    "@apollo/federation-internals" "2.5.7"
+    "@apollo/query-graphs" "2.5.7"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
     chalk "^4.1.0"
     deep-equal "^2.0.5"
     pretty-format "^29.0.0"
 
-"@apollo/server-gateway-interface@^1.0.2":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.4.tgz#e92139ea90f03ce70e87487680428cced4f38f56"
-  integrity sha512-zXbFjrpL0VXfYV8ecOWUKjbUmhgfUx9JzXCPZq/qg+ndwH3WhRFp7Pog45/OfkjPeBXTCeote1cxeDNDkQ2FVg==
+"@apollo/server-gateway-interface@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/server-gateway-interface/-/server-gateway-interface-1.1.1.tgz#a79632aa921edefcd532589943f6b97c96fa4d3c"
+  integrity sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==
   dependencies:
-    "@apollo/usage-reporting-protobuf" "^4.0.0"
-    "@apollo/utils.fetcher" "^1.0.0"
-    "@apollo/utils.keyvaluecache" "^1.0.1"
-    "@apollo/utils.logger" "^1.0.0"
+    "@apollo/usage-reporting-protobuf" "^4.1.1"
+    "@apollo/utils.fetcher" "^2.0.0"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
+    "@apollo/utils.logger" "^2.0.0"
 
 "@apollo/subgraph@^0.5.1":
   version "0.5.1"
@@ -150,38 +151,38 @@
   dependencies:
     "@apollo/cache-control-types" "^1.0.2"
 
-"@apollo/subgraph@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@apollo/subgraph/-/subgraph-2.2.1.tgz#56d9a87a36e546354c433a4121d31615dd934289"
-  integrity sha512-fAm7KXr54/5mDA2mhR36AI8rwiaPGHpT9s51t8mOpnKNpX8vc9KrdlPqCAF88LKVxKRZBDTNjlD5sRgx0tQl5w==
+"@apollo/subgraph@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@apollo/subgraph/-/subgraph-2.5.7.tgz#f0a3379359cb146f3552c560997ec4d4a076aae8"
+  integrity sha512-XEpawcRL7JEmUbJsFOgFYsUDbsA+392kexch9EIlZWfc1afZmhLjzPOIAgn+KO9ohwOLkkmRjczehDwzQgYFkA==
   dependencies:
     "@apollo/cache-control-types" "^1.0.2"
-    "@apollo/federation-internals" "^2.2.1"
+    "@apollo/federation-internals" "2.5.7"
 
-"@apollo/usage-reporting-protobuf@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.0.0.tgz#36db64164f511508822bc8ac8fedb850f43af86e"
-  integrity sha512-MyQIaDkePoYbqMdwuubfUdUELT1ozpfBM1poV7x5S44Qs2b+247ni4+sqt1W/3cXC8WiJVmfUXJ9QcPGIOqu5w==
+"@apollo/usage-reporting-protobuf@^4.1.0", "@apollo/usage-reporting-protobuf@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz#407c3d18c7fbed7a264f3b9a3812620b93499de1"
+  integrity sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==
   dependencies:
-    "@apollo/protobufjs" "1.2.6"
+    "@apollo/protobufjs" "1.2.7"
 
-"@apollo/utils.createhash@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@apollo/utils.createhash/-/utils.createhash-1.1.0.tgz#b18a353008d2583a34eaebaf471aff6e15360172"
-  integrity sha512-5fT4ZiW75515OlikWpIQzaVDws1yy9VgYSoHoJCrvI2UH6/7YNKXQjbjT5qVYu6ytch2wBxFMfFfYWMn/2bSCQ==
+"@apollo/utils.createhash@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.createhash/-/utils.createhash-2.0.1.tgz#9d982a166833ce08265ff70f8ef781d65109bdaa"
+  integrity sha512-fQO4/ZOP8LcXWvMNhKiee+2KuKyqIcfHrICA+M4lj/h/Lh1H10ICcUtk6N/chnEo5HXu0yejg64wshdaiFitJg==
   dependencies:
-    "@apollo/utils.isnodelike" "^1.1.0"
+    "@apollo/utils.isnodelike" "^2.0.1"
     sha.js "^2.4.11"
 
-"@apollo/utils.fetcher@^1.0.0", "@apollo/utils.fetcher@^1.1.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@apollo/utils.fetcher/-/utils.fetcher-1.1.1.tgz#909974d9c98fdd0ad64808596860a11cbb2a6afa"
-  integrity sha512-0vXVznO7kw5VWwxyV5wsDvYEwjDpyZ7vYQAXCseLXqBn2eWEIDViM7qRzi/Hnv4zzAQ05phdimSED99K+lg+SQ==
+"@apollo/utils.fetcher@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.fetcher/-/utils.fetcher-2.0.1.tgz#2f6e3edc8ce79fbe916110d9baaddad7e13d955f"
+  integrity sha512-jvvon885hEyWXd4H6zpWeN3tl88QcWnHp5gWF5OPF34uhvoR+DFqcNxs9vrRaBBSY3qda3Qe0bdud7tz2zGx1A==
 
-"@apollo/utils.isnodelike@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@apollo/utils.isnodelike/-/utils.isnodelike-1.1.0.tgz#24d3f36276b6ba4b08117925083bc5c5f2513c3d"
-  integrity sha512-q/Q82kBUSEcx1ED11JO1TYBY781mWluUnBD8NvhjHVsu1K1C5R9BZVUxShyK/V8XcePcRUB5fdWOcBMGwS0KOA==
+"@apollo/utils.isnodelike@^2.0.0", "@apollo/utils.isnodelike@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.1.tgz#08a7e50f08d2031122efa25af089d1c6ee609f31"
+  integrity sha512-w41XyepR+jBEuVpoRM715N2ZD0xMD413UiJx8w5xnAZD2ZkSJnMJBoIzauK83kJpSgNuR6ywbV29jG9NmxjK0Q==
 
 "@apollo/utils.keyvaluecache@^1.0.1":
   version "1.0.1"
@@ -191,10 +192,23 @@
     "@apollo/utils.logger" "^1.0.0"
     lru-cache "^7.10.1"
 
+"@apollo/utils.keyvaluecache@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.1.tgz#f3f79a2f00520c6ab7a77a680a4e1fec4d19e1a6"
+  integrity sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==
+  dependencies:
+    "@apollo/utils.logger" "^2.0.1"
+    lru-cache "^7.14.1"
+
 "@apollo/utils.logger@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@apollo/utils.logger/-/utils.logger-1.0.0.tgz#6e3460a2250c2ef7c2c3b0be6b5e148a1596f12b"
   integrity sha512-dx9XrjyisD2pOa+KsB5RcDbWIAdgC91gJfeyLCgy0ctJMjQe7yZK5kdWaWlaOoCeX0z6YI9iYlg7vMPyMpQF3Q==
+
+"@apollo/utils.logger@^2.0.0", "@apollo/utils.logger@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.logger/-/utils.logger-2.0.1.tgz#74faeb97d7ad9f22282dfb465bcb2e6873b8a625"
+  integrity sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==
 
 "@ardatan/relay-compiler@12.0.0":
   version "12.0.0"
@@ -1716,10 +1730,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+"@types/uuid@^9.0.0":
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.7.tgz#b14cebc75455eeeb160d5fe23c2fcc0c64f724d8"
+  integrity sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==
 
 "@types/ws@^8.0.0":
   version "8.5.3"
@@ -4552,10 +4566,10 @@ lru-cache@^7.10.1, lru-cache@^7.7.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.13.1.tgz#267a81fbd0881327c46a81c5922606a2cfe336c4"
   integrity sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==
 
-lru-cache@^7.13.1:
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.0.tgz#21be64954a4680e303a09e9468f880b98a0b3c7f"
-  integrity sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==
+lru-cache@^7.14.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -5799,10 +5813,10 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-ts-graphviz@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/ts-graphviz/-/ts-graphviz-0.16.0.tgz#7a6e6b5434854bc90ab861e70d5af0d6d20729a7"
-  integrity sha512-3fTPO+G6bSQNvMh/XQQzyiahVLMMj9kqYO99ivUraNJ3Wp05HZOOVtRhi6w9hq7+laP1MKHjLBtGWqTeb1fcpg==
+ts-graphviz@^1.5.4:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/ts-graphviz/-/ts-graphviz-1.8.1.tgz#5d95e58120be8b571847331516327d4840cc44f7"
+  integrity sha512-54/fe5iu0Jb6X0pmDmzsA2UHLfyHjUEUwfHtZcEOR0fZ6Myf+dFoO6eNsyL8CBDMJ9u7WWEewduVaiaXlvjSVw==
 
 ts-log@^2.2.3:
   version "2.2.4"


### PR DESCRIPTION
- `@apollo/federation-internals` has a breaking change between 2.2 and 2.5 preventing the application from building supergraph schema